### PR TITLE
Fix container failing to start in analytics mode

### DIFF
--- a/server/5.1/files/entrypoint.sh
+++ b/server/5.1/files/entrypoint.sh
@@ -11,6 +11,12 @@ set -e
 
 link_external_config "${DSE_HOME}"
 
+#create directories for holding the node's data, logs, etc.
+mkdir -p /var/lib/spark/worker
+mkdir -p /var/lib/spark/rdd
+mkdir -p /var/log/spark/worker
+mkdir -p /var/log/spark/master
+
 ############################################
 # Set up variables/configure the image
 ############################################


### PR DESCRIPTION
Added to dse-server entrypoint.sh the below directories to allow dse in analytics mode with the checks added in DSP-1324. Tested that dse starts in analytics mode

#create directories for holding the node's data, logs, etc.
 mkdir -p /var/lib/spark/worker
 mkdir -p /var/lib/spark/rdd 
mkdir -p /var/log/spark/worker 
mkdir -p /var/log/spark/master
