### PR TITLE
correcting name of volume to config

### DIFF
--- a/opscenter.md
+++ b/opscenter.md
@@ -132,4 +132,3 @@ Use the Docker images maintained by [DataStax](https://www.datastax.com/):
 ## Licensing terms
 * [OpsCenter License Terms](https://www.datastax.com/datastax-opscenter-license-terms)
 * [DataStax License Terms](https://www.datastax.com/terms)
-* [DataStax License Terms](https://www.datastax.com/terms)


### PR DESCRIPTION
In https://github.com/datastax/docker-images/blob/master/base/files/base-checks.sh#L8
the link_external_config function is expecting the volume to be `config` not `conf` so the README was incorrect.
This patch fixes the Readme