### PR TITLE
fix: external config files will not be additionally auto-configured.

### DIFF
--- a/base/files/base-checks.sh
+++ b/base/files/base-checks.sh
@@ -3,6 +3,8 @@
 # if their counterparts exist in /config folder
 ############################################
 
+declare -A linkedExternalConf
+
 function link_external_config {
     for conf_file in $(cat /overwritable-conf-files) ; do
         ext_conf_file="/config/$(basename "$conf_file")"
@@ -11,8 +13,33 @@ function link_external_config {
             echo "Linking $embedded_conf_file to $ext_conf_file"
             mkdir -p "$(dirname "$embedded_conf_file")"
             ln -sf "$ext_conf_file" "$embedded_conf_file"
+            linkedExternalConf["$embedded_conf_file"]="$ext_conf_file"
         fi
     done
+}
+
+function is_external_file {
+
+    MP="$(df --output=target "$1" | tail -n +2)"
+    if [ "$MP" != "/" ] && grep -q "^Users $MP" /proc/mounts ; then
+        echo "$1 mount point is $MP"
+        true
+    else
+        false
+    fi
+}
+
+function should_auto_configure {
+
+    if [ ! -z "$DSE_AUTO_CONF_OFF" ]; then
+        false
+    else
+        if is_external_file "$1" ; then
+            false
+        else
+            true
+        fi
+    fi
 }
 
 ############################################

--- a/server/5.1/files/entrypoint.sh
+++ b/server/5.1/files/entrypoint.sh
@@ -23,10 +23,10 @@ mkdir -p /var/log/spark/master
 
 IP_ADDRESS="$(hostname --ip-address)"
 CASSANDRA_CONFIG="${DSE_HOME}/resources/cassandra/conf/cassandra.yaml"
+CASSANDRA_RACK_CONFIG="${DSE_HOME}/resources/cassandra/conf/cassandra-rackdc.properties"
 
 # SNITCH sets the snitch this node will use. Use GossipingPropertyFileSnitch if not set
 : ${SNITCH=GossipingPropertyFileSnitch}
-sed -ri 's/(endpoint_snitch:).*/\1 '"$SNITCH"'/' "$CASSANDRA_CONFIG"
 
 # RPC_ADDRESS is where we listen for drivers/clients to connect to us. Setting to 0.0.0.0 by default is fine
 # since we'll be specifying the BROADCAST_RPC_ADDRESS below
@@ -53,33 +53,45 @@ fi
 # default to ourself
 : ${SEEDS:="$BROADCAST_ADDRESS"}
 
-# Replace the default seeds setting in cassandra.yaml
-sed -ri 's/(- seeds:).*/\1 "'"$SEEDS"'"/' "$CASSANDRA_CONFIG"
+# modify cassandra.yaml only if not linked externally
+if should_auto_configure "$CASSANDRA_CONFIG" ; then
+    echo "Applying changes to $CASSANDRA_CONFIG ..."
 
-# Update the following settings in the cassandra.yaml file based on the ENV variable values
-for name in \
-    broadcast_address \
-    broadcast_rpc_address \
-    cluster_name \
-    listen_address \
-    num_tokens \
-    rpc_address \
-    start_rpc \
-    ; do
-    var="${name^^}"
-    val="${!var}"
-    if [ "$val" ]; then
-      sed -ri 's/^(# )?('"$name"':).*/\2 '"$val"'/' "$CASSANDRA_CONFIG"
-    fi
-done
+    sed -ri 's/(endpoint_snitch:).*/\1 '"$SNITCH"'/' "$CASSANDRA_CONFIG"
 
-for rackdc in dc rack; do
-    var="${rackdc^^}"
-    val="${!var}"
-    if [ "$val" ]; then
-        sed -ri 's/^('"$rackdc"'=).*/\1 '"$val"'/' "${DSE_HOME}/resources/cassandra/conf/cassandra-rackdc.properties"
-    fi
-done
+    # Replace the default seeds setting in cassandra.yaml
+    sed -ri 's/(- seeds:).*/\1 "'"$SEEDS"'"/' "$CASSANDRA_CONFIG"
+
+    # Update the following settings in the cassandra.yaml file based on the ENV variable values
+    for name in \
+        broadcast_address \
+        broadcast_rpc_address \
+        cluster_name \
+        listen_address \
+        num_tokens \
+        rpc_address \
+        start_rpc \
+        ; do
+        var="${name^^}"
+        val="${!var}"
+        if [ "$val" ]; then
+          sed -ri 's/^(# )?('"$name"':).*/\2 '"$val"'/' "$CASSANDRA_CONFIG"
+        fi
+    done
+    echo "done."
+fi
+
+if should_auto_configure "$CASSANDRA_RACK_CONFIG" ; then
+    echo "Applying changes to $CASSANDRA_RACK_CONFIG ..."
+    for rackdc in dc rack; do
+        var="${rackdc^^}"
+        val="${!var}"
+        if [ "$val" ]; then
+            sed -ri 's/^('"$rackdc"'=).*/\1 '"$val"'/' "$CASSANDRA_RACK_CONFIG"
+        fi
+    done
+    echo "done."
+fi
 
 [ -z "$OPSCENTER_IP" ] && OPSCENTER_IP=$(getent hosts opscenter | awk '{ print $1 }')
 if [ ! -z "$OPSCENTER_IP" ]; then


### PR DESCRIPTION
The external config files will be properly detected in all cases:
* mounted from outside using `-v /foo/conf:/config`
* mounted directly using `-v /foo/mycassandra.yaml:/opt/dse/resources/cassandra/conf/cassandra.yaml`
* mounted in a directory using `-v /foo/mycassandraConf:/opt/dse/resources/cassandra/conf`

Finally, auto-configuring can be fully disabled by providing any value to `DSE_AUTO_CONF_OFF` env varibale