### PR TITLE
Fix warning that will become error in next Docker versions

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install ca-certificates curl wget sysstat locales 
 	mkdir -p /usr/lib/jvm && mv /tmp/jdk* "${JAVA_HOME}" && \
 	apt-get autoclean && apt-get --purge -y autoremove && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-
+        \
     update-alternatives --install "/usr/bin/java" "java" "${JRE_HOME}/bin/java" 1 && \
 	update-alternatives --install "/usr/bin/javaws" "javaws" "${JRE_HOME}/bin/javaws" 1 && \
 	update-alternatives --install "/usr/bin/javac" "javac" "${JAVA_HOME}/bin/javac" 1 && \


### PR DESCRIPTION
This commit fixes following warning from Docker:

```
[WARNING]: Empty continuation line found in:
.... commands....
[WARNING]: Empty continuation lines will become errors in a future release.
```