### PR TITLE
Make server Docker images slimmer by removing some duplicates

### DIFF
--- a/server/5.1/Dockerfile
+++ b/server/5.1/Dockerfile
@@ -51,7 +51,11 @@ RUN set -x \
 # Create folders
     && (for dir in /var/lib/cassandra /var/lib/spark /var/lib/dsefs /var/lib/datastax-agent /var/log/cassandra /var/log/spark /config ; do \
         mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
-    done )
+    done ) \
+# Replace duplicate Spark files by hard links
+    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* \
+    && ln $DSE_HOME/clients/dse-byos_* $DSE_HOME/resources/spark/client-lib/ \
+    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME

--- a/server/5.1/Dockerfile
+++ b/server/5.1/Dockerfile
@@ -53,9 +53,9 @@ RUN set -x \
         mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
     done ) \
 # Replace duplicate Spark files by hard links
-    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* \
-    && ln $DSE_HOME/clients/dse-byos_* $DSE_HOME/resources/spark/client-lib/ \
-    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done
+    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* $DSE_HOME/clients/dse-byos_* \
+    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done \
+    && for i in $DSE_HOME/resources/hadoop2-client/lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/client-lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/client-lib/`basename $i` $i ; fi ; done
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME

--- a/server/6.0/Dockerfile
+++ b/server/6.0/Dockerfile
@@ -50,7 +50,11 @@ RUN set -x \
 # Create folders
     && (for dir in /var/lib/cassandra /var/lib/spark /var/lib/dsefs /var/lib/datastax-agent /var/log/cassandra /var/log/spark /config ; do \
         mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
-    done )
+    done ) \
+# Replace duplicate Spark files by hard links
+    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* \
+    && ln $DSE_HOME/clients/dse-byos_* $DSE_HOME/resources/spark/client-lib/ \
+    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME

--- a/server/6.0/Dockerfile
+++ b/server/6.0/Dockerfile
@@ -52,9 +52,9 @@ RUN set -x \
         mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
     done ) \
 # Replace duplicate Spark files by hard links
-    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* \
-    && ln $DSE_HOME/clients/dse-byos_* $DSE_HOME/resources/spark/client-lib/ \
-    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done
+    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* $DSE_HOME/clients/dse-byos_* \
+    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done \
+    && for i in $DSE_HOME/resources/hadoop2-client/lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/client-lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/client-lib/`basename $i` $i ; fi ; done
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME

--- a/server/6.7/Dockerfile
+++ b/server/6.7/Dockerfile
@@ -50,7 +50,11 @@ RUN set -x \
 # Create folders
     && (for dir in /var/lib/cassandra /var/lib/spark /var/lib/dsefs /var/lib/datastax-agent /var/log/cassandra /var/log/spark /config ; do \
         mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
-    done )
+    done ) \
+# Replace duplicate Spark files by hard links
+    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* \
+    && ln $DSE_HOME/clients/dse-byos_* $DSE_HOME/resources/spark/client-lib/ \
+    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME

--- a/server/6.7/Dockerfile
+++ b/server/6.7/Dockerfile
@@ -52,9 +52,9 @@ RUN set -x \
         mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
     done ) \
 # Replace duplicate Spark files by hard links
-    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* \
-    && ln $DSE_HOME/clients/dse-byos_* $DSE_HOME/resources/spark/client-lib/ \
-    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done
+    && rm -f $DSE_HOME/resources/spark/client-lib/dse-byos_* $DSE_HOME/clients/dse-byos_* \
+    && for i in $DSE_HOME/resources/spark/client-lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/lib/`basename $i` $i ; fi ; done \
+    && for i in $DSE_HOME/resources/hadoop2-client/lib/*.jar ; do if [ -f $DSE_HOME/resources/spark/client-lib/`basename $i` ] ; then rm -f $i ; ln $DSE_HOME/resources/spark/client-lib/`basename $i` $i ; fi ; done
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME


### PR DESCRIPTION
Duplicate files are replaced with hard links. This includes `dse-byos...jar` and in
`resources/spark/client/lib`.

This allowed to chop around 200Mb from image:

- Before (5.1.11): 1.36GB
- After (5.1.11) : 1.15GB
- Before (6.7.0): 1.5GB
- After (6.7.0) : 1.3GB