### PR TITLE
Change FROM image to Red Hat Universal Base Image (UBI) 7

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,23 +1,24 @@
 # Copyright DataStax, Inc, 2017
 #   Please review the included LICENSE file for more information.
 #
-FROM openjdk:8u171-jdk-slim-stretch
+
+# Based on ubi7 for Python 2 support, when moving to Python 3 use ubi8
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 MAINTAINER "DataStax, Inc <info@datastax.com>"
 
-ENV DEBIAN_FRONTEND noninteractive
+RUN microdnf update && rm -rf /var/cache/yum
 
-RUN apt-get update && apt-get install wget sysstat locales -y --no-install-recommends && \
-	apt-get autoclean && apt-get --purge -y autoremove && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	# Comment out Assistive Technologies to run the grimlin console from docker exec
-         sed -i -e '/^assistive_technologies=/s/^/#/' /etc/java-*-openjdk/accessibility.properties && \
-	echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-	# set the locale of the container:
-    locale-gen
+# Missing sysstat package, en_US.UTF-8 is the default, and only, locale in ubi-minimal
+RUN microdnf install wget java-1.8.0-openjdk lm_sensors-libs  && microdnf clean all
+# 	# Comment out Assistive Technologies to run the grimlin console from docker exec
+#          sed -i -e '/^assistive_technologies=/s/^/#/' /etc/java-*-openjdk/accessibility.properties
 
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US.UTF-8
+# HACK: This is janky and needs to be reviewed
+RUN set -x \
+# Download sysstat RPM and install
+    && wget -nv http://mirror.centos.org/centos/8/AppStream/x86_64/os/Packages/sysstat-11.7.3-2.el8.x86_64.rpm \
+    && rpm -i ./sysstat* \
+    && rm sysstat-*
 
 ADD files /

--- a/server/Dockerfile.ftl
+++ b/server/Dockerfile.ftl
@@ -7,20 +7,11 @@ FROM dse-base as dse-server-base
 ENV DSE_HOME /opt/dse
 ENV DSE_AGENT_HOME /opt/agent
 
-RUN set -x \
-# Add DSE user
-    && groupadd -r dse --gid=999 \
-    && useradd -m -d "$DSE_HOME" -r -g dse --uid=999 dse
+# Add DSE user, changed from 999 as it was already present in base
+RUN groupadd -r dse --gid=1025 && useradd -m -d "$DSE_HOME" -r -g dse --uid=1025 dse
 
 # Install missing packages
-RUN set -x \
-    && apt-get update -qq \
-    && apt-get install -y python adduser lsb-base procps gzip zlib1g wget debianutils libaio1 sudo \
-    && apt-get remove -y python3 \
-    && apt-get autoremove --yes \
-    && apt-get clean all \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}/
-
+RUN microdnf install python procps-ng gzip zlib libaio tar hostname wget which findutils && microdnf clean all
 
 FROM dse-server-base as base
 


### PR DESCRIPTION
This PR changes the FROM Dockerfile lines to registry.access.redhat.com/ubi7/ubi-minimal:latest.

Additionally, adjustments have been made given the shift from the Debian base to Red Hat.