### PR TITLE
Using openjdk:8-jdk-slim-buster to support ARM64 in base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright DataStax, Inc, 2017
 #   Please review the included LICENSE file for more information.
 #
-FROM openjdk:8u171-jdk-slim-stretch
+FROM openjdk:8-jdk-slim-buster
 
 MAINTAINER "DataStax, Inc <info@datastax.com>"
 
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install wget sysstat locales -y --no-install-recom
 	apt-get autoclean && apt-get --purge -y autoremove && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 	# Comment out Assistive Technologies to run the grimlin console from docker exec
-         sed -i -e '/^assistive_technologies=/s/^/#/' /etc/java-*-openjdk/accessibility.properties && \
+  #       sed -i -e '/^assistive_technologies=/s/^/#/' /etc/java-*-openjdk/accessibility.properties && \
 	echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
 	# set the locale of the container:
     locale-gen


### PR DESCRIPTION
Using buster base image to support ARM64 as well